### PR TITLE
ENG-2235: Newsletter signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 Cloud functions for [Open-Source Hub](https://github.com/Codesee-io/opensourcehub).
 
+We use these to identify and track users in Open Source Hub by hooking onto Firestore lifecycle events.
+
 ## Contributing
 
 ### Requirements
 
-You'll need the `firebase-tools` package installed globally:
+You'll need the `firebase-tools@11.21` package installed globally:
 
 ```
 npm i -g firebase-tools
@@ -25,10 +27,14 @@ Note that the structure of this repo differs from regular Node/JavaScript repos:
    SEGMENT_WRITE_KEY="... find this in Segment"
    ```
 
+5. Run the emulator: `yarn serve`
+
+TODO this is incomplete! How do we test the functions?
+
 ## Deployment
 
 Run the command below at the root of the repo:
 
 ```
-firebase deploy
+firebase deploy --only functions
 ```


### PR DESCRIPTION
### What changed:

With https://github.com/Codesee-io/opensourcehub/pull/250, we added a checkbox to OSH that allows users tosubscribe to our newsletter. This boolean value is stored in the `profiles` collection in Firestore as `joinNewsletter`.

We want this field to end up in HubSpot as `send_me_osh_news: true/false`. To do that, we've set up cloud functions that listen to updates in the `profiles` collection. When an item in that collection gets updated, the `joinNewsletter` field is passed to `Segment.identify()` as the `send_me_osh_news` field. Once Segment receives that, it'll send the data into HubSpot according to Eden's setup.

In short:

OSH UI -> Firestore -> Cloud functions -> Segment -> Hubspot